### PR TITLE
Removed unneeded -ms-filter declarations and various small corrections

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <title>CSS3 Please! The Cross-Browser CSS3 Rule Generator</title>
   <link rel="stylesheet" href="css/stylesheet.css" media="screen">
   
-<script>if (((navigator.plugins && typeof navigator.plugins['Shockwave Flash'] == 'object') || (window.ActiveXObject && (new ActiveXObject('ShockwaveFlash.ShockwaveFlash')))) && location.protocol != 'file:') document.documentElement.className = 'flash'; </script>
+<script>if (((navigator.plugins && typeof navigator.plugins['Shockwave Flash'] == 'object') || (window.ActiveXObject && (new ActiveXObject('ShockwaveFlash.ShockwaveFlash')))) && location.protocol != 'file:') document.documentElement.className = 'flash';</script>
 
 <!-- its only up here because the js does syntax highlighting so i want the js loaded before the page loads. bad practice i know... -->
 <script src="javascript/jquery-1.4.2.js"></script>
@@ -49,7 +49,7 @@
 .box_round {
      -moz-border-radius: <b g="0">12px</b>; <span class="comment">/* FF1+ <span class="endcomment">*/</span></span>
   -webkit-border-radius: <b g="0">12px</b>; <span class="comment">/* Saf3-4 <span class="endcomment">*/</span></span>
-          border-radius: <b g="0">12px</b>; <span class="comment">/* Opera 10.5, IE 9, Saf5, Chrome <span class="endcomment">*/</span></span>
+          border-radius: <b g="0">12px</b>; <span class="comment">/* Opera 10.5, IE9, Saf5, Chrome <span class="endcomment">*/</span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>
@@ -63,7 +63,7 @@
     -webkit-border-top-right-radius: <b g="2" readonly>8px</b>;
  -webkit-border-bottom-right-radius: <b g="3" readonly>0px</b>;
   -webkit-border-bottom-left-radius: <b g="4" readonly>0px</b>;
-          border-radius: <b g="0">8px 8px 0px 0px</b>; <span class="comment">/* Opera 10.5, IE 9, Saf5, Chrome <span class="endcomment">*/</span></span>
+          border-radius: <b g="0">8px 8px 0px 0px</b>; <span class="comment">/* Opera 10.5, IE9, Saf5, Chrome <span class="endcomment">*/</span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>
@@ -75,7 +75,7 @@
 .box_shadow {
      -moz-box-shadow: <b g="0">0px</b> <b g="1">0px</b> <b g="2">4px</b> <b g="3" i="s2Hex" o="sHex">#ffffff</b>; <span class="comment">/* FF3.5+ <span class="endcomment">*/</span></span>
   -webkit-box-shadow: <b g="0">0px</b> <b g="1">0px</b> <b g="2">4px</b> <b g="3" i="s2Hex" o="sHex">#ffffff</b>; <span class="comment">/* Saf3.0+, Chrome <span class="endcomment">*/</span></span>
-          box-shadow: <b g="0">0px</b> <b g="1">0px</b> <b g="2">4px</b> <b g="3" i="s2Hex" o="sHex">#ffffff</b>; <span class="comment">/* Opera 10.5, IE 9 <span class="endcomment">*/</span></span>
+          box-shadow: <b g="0">0px</b> <b g="1">0px</b> <b g="2">4px</b> <b g="3" i="s2Hex" o="sHex">#ffffff</b>; <span class="comment">/* Opera 10.5, IE9 <span class="endcomment">*/</span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>
@@ -87,8 +87,7 @@
   background-color: <b g="0" i="s2Hex">#444444</b>;
   background-image: -moz-linear-gradient(top, <b g="0" i="s2Hex">#444444</b>, <b g="1" i="s2Hex">#999999</b>); <span class="comment">/* FF3.6 <span class="endcomment">*/</span></span>
   background-image: -webkit-gradient(linear,left top,left bottom,color-stop(0, <b g="0" i="s2Hex">#444444</b>),color-stop(1, <b g="1" i="s2Hex">#999999</b>)); <span class="comment">/* Saf4+, Chrome <span class="endcomment">*/</span></span>
-            <span class="ie">filter:  <span class="filter">progid:DXImageTransform.Microsoft.gradient(startColorStr='<b g="0" i="s2Hex">#444444</b>', EndColorStr='<b g="1" i="s2Hex">#999999</b>')</span>; <span class="comment">/* IE6,IE7 <span class="endcomment">*/</span></span>
-        -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr='<b g="0" i="s2Hex">#444444</b>', EndColorStr='<b g="1" i="s2Hex">#999999</b>')"; <span class="comment">/* IE8 <span class="endcomment">*/</span></span></span>
+            <span class="ie">filter: <span class="filter">progid:DXImageTransform.Microsoft.gradient(startColorStr='<b g="0" i="s2Hex">#444444</b>', EndColorStr='<b g="1" i="s2Hex">#999999</b>')</span>; <span class="comment">/* IE6–IE9 <span class="endcomment">*/</span></span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>
@@ -101,8 +100,7 @@
 .box_rgba {
   background-color: <b g="0" i="ch" o="shortHex" readonly>#B4B490</b>;
   background-color: <b g="0" i="s2aHex" o="aCh">rgba(180, 180, 144, 0.6)</b>;  <span class="comment">/* FF3+, Saf3+, Opera 10.10+, Chrome, IE9 <span class="endcomment">*/</span></span>
-            <span class="ie">filter:  <span class="filter">progid:DXImageTransform.Microsoft.gradient(startColorStr='<b g="0" i="s2aHex">#99B4B490</b>',EndColorStr='<b g="0" i="s2aHex">#99B4B490</b>')</span>; <span class="comment">/* IE6,IE7 <span class="endcomment">*/</span></span>
-        -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr='<b g="0" i="s2aHex">#99B4B490</b>',EndColorStr='<b g="0" i="s2aHex">#99B4B490</b>')"; <span class="comment">/* IE8 <span class="endcomment">*/</span></span></span>
+            <span class="ie">filter: <span class="filter">progid:DXImageTransform.Microsoft.gradient(startColorStr='<b g="0" i="s2aHex">#99B4B490</b>',EndColorStr='<b g="0" i="s2aHex">#99B4B490</b>')</span>; <span class="comment">/* IE6–IE9 <span class="endcomment">*/</span></span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>
@@ -116,10 +114,8 @@
   -webkit-transform: rotate(<b g="0">7.5</b>deg);  <span class="comment">/* Saf3.1+, Chrome <span class="endcomment">*/</span></span>
       -ms-transform: rotate(<b g="0">7.5</b>deg);  <span class="comment">/* IE9 <span class="endcomment">*/</span></span>
           transform: rotate(<b g="0">7.5</b>deg);  
-             <span class="ie">filter:  <span class="filter">progid:DXImageTransform.Microsoft.Matrix(sizingMethod='auto expand', <span class="comment">/* IE6,IE7 <span class="endcomment">*/</span></span> 
-                      <b g="0" i="matrix2deg" o="deg2matrix" readonly>M11=0.9914448613738104, M12=-0.13052619222005157,M21=0.13052619222005157, M22=0.9914448613738104</b>)</span>; 
-         -ms-filter: <span class="msFilter">"progid:DXImageTransform.Microsoft.Matrix(<b g="0" i="matrix2deg" o="deg2matrix" readonly>M11=0.9914448613738104, M12=-0.13052619222005157, M21=0.13052619222005157, M22=0.9914448613738104</b>,sizingMethod='auto expand')"</span>; 
-                      <span class="comment">/* IE8 <span class="endcomment">*/</span></span></span>
+             <span class="ie">filter: <span class="filter">progid:DXImageTransform.Microsoft.Matrix(sizingMethod='auto expand', <span class="comment">/* IE6–IE9 <span class="endcomment">*/</span></span> 
+                     <b g="0" i="matrix2deg" o="deg2matrix" readonly>M11=0.9914448613738104, M12=-0.13052619222005157,M21=0.13052619222005157, M22=0.9914448613738104</b>)</span>;</span></span>
                zoom: 1;
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
@@ -155,10 +151,10 @@
   <pre class="rule">
 @font-face {
   font-family: '<b g="1">WebFont</b>';
-  src: url('<b g="0">myfont</b>.eot');  <span class="comment">/* IE6-8 <span class="endcomment">*/</span></span>
+  src: url('<b g="0">myfont</b>.eot');  <span class="comment">/* IE6–8 <span class="endcomment">*/</span></span>
   src: local('☺'), 
         url('<b g="0">myfont</b>.woff') format('woff'),  <span class="comment">/* FF3.6, IE9 <span class="endcomment">*/</span></span>
-        url('<b g="0">myfont</b>.ttf') format('truetype');  <span class="comment">/* Saf3+,Chrome,FF3.5,Opera10+ <span class="endcomment">*/</span></span>
+        url('<b g="0">myfont</b>.ttf') format('truetype');  <span class="comment">/* Saf3+, Chrome, FF3.5, Opera 10+ <span class="endcomment">*/</span></span>
 }</pre>
   <!--  <pre class="rule comment commentclose"><span class="comment">/* */</span></pre> -->
 </div>
@@ -199,7 +195,8 @@
     2010.06.02: Clipboard click strips comments
     2010.10.05: Unprefixed transitions, transforms
     2010.11.06: Toggle to light skin (Thx <a href="http://curtisblackwell.com/">Curtis Blackwell</a>!). IE9 Transform added. Clipboard only grabs rules, no selector.
-    2010.11.19: Better handling of users without Flash. (Thx <a href="http://mathiasbynens.be/notes">Mathias</a>)
+    2010.11.19: Better handling of users without Flash. (Thx <a href="http://mathiasbynens.be/">Mathias</a>)
+    2011.01.05: Removed unneeded <code>-ms-filter</code> declarations. (Thx <a href="http://mathiasbynens.be/">Mathias</a>)
 */
 
 


### PR DESCRIPTION
- Removed unneeded `-ms-filter` declarations.
- Removed double space after `filter:`.
- Updated which browsers support which techniques. Be aware that `filter` still works in IE9! This means that some of the existing generated CSS will apply e.g. `rgba` **AND** `filter` in IE9. My commit doesn’t fix any of that (although it corrects the browser support comments, implying that this will happen), but it’s definitely something to consider. A solution would be to use a variant of http://paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ and then do something like `.ie9 .rgba { filter: none; }` (or `filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);` in case the former doesn’t work).
