### PR TITLE
added the background-clip rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,8 @@
     2012.03.01: Went one year into the future to make a minor text change. Phew!
     2011.03.15: Added linear gradients for Opera 11.10. (Thanks, <a href="http://miketaylr.com/">Mike</a>!)
     2011.03.26: Added Ceaser link.
-    2011.04.07: Added <a href="https://developer.mozilla.org/en/CSS/background-size">background-size</a> (thx codler!). 
+    2011.04.07: Added <a href="https://developer.mozilla.org/en/CSS/background-size">background-size</a> (thx codler!).
+    2011.04.11: Added <a href="https://developer.mozilla.org/en/CSS/background-clip">background-clip</a>.
 */
 
 


### PR DESCRIPTION
I think background-clip: padding-box is what people will want 99% of the time (why isn't it the browser default?) to prevent the bg color from creeping out
