### PR TITLE
Shouldn't we add   -o-background-clip: padding; to the border radius rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           border-radius: <b g="0">12px</b>; <span class="comment">/* Opera 10.5, IE9, Saf5, Chrome, FF4, iOS 4, Android 2.1+ <span class="endcomment">*/</span></span>
           
   <span class="comment">/* useful if you don't want a bg color from <a href="http://tumble.sneak.co.nz/post/928998513/fixing-the-background-bleed">leaking outside</a> the border: */</span>        
-  -moz-background-clip: padding; -webkit-background-clip: padding-box; background-clip: padding-box; 
+  -moz-background-clip: padding; -o-background-clip: padding; -webkit-background-clip: padding-box; background-clip: padding-box; 
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>


### PR DESCRIPTION
Shouldn't we add   -o-background-clip: padding; to the border radius rule generator? 
