### PR TITLE
Update linear-gradient syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
   <pre class="rule comment">/*                           <a class="cb">[to clipboard]</a> <a class="off">[toggle rule off]</a> <span class="endcomment">*/</span></pre>
   <pre class="rule">
 .box_round {
-  -webkit-border-radius: <b g="0">12px</b>; <span class="comment">/* Saf3-4, iOS 1-3.2, Android &lte;1.6 <span class="endcomment">*/</span></span>
+  -webkit-border-radius: <b g="0">12px</b>; <span class="comment">/* Saf3-4, iOS 1-3.2, Android &le;1.6 <span class="endcomment">*/</span></span>
      -moz-border-radius: <b g="0">12px</b>; <span class="comment">/* FF1-3.6 <span class="endcomment">*/</span></span>
           border-radius: <b g="0">12px</b>; <span class="comment">/* Opera 10.5, IE9, Saf5, Chrome, FF4, iOS 4, Android 2.1+ <span class="endcomment">*/</span></span>
 


### PR DESCRIPTION
Issue #77 #78

PR for updating linear-gradient syntax.   Link to reference in #78 was down due to Sopa strike but same info was found here. https://developer.mozilla.org/en/CSS/linear-gradient

Thanks!

Scott
