### PR TITLE
Closing span tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
      -moz-transform: rotate(<b g="0">7.5</b>deg);  <span class="comment">/* Firefox 3.5-15 <span class="endcomment">*/</span></span>
       -ms-transform: rotate(<b g="0">7.5</b>deg);  <span class="comment">/* IE9+ <span class="endcomment">*/</span></span>
        -o-transform: rotate(<b g="0">7.5</b>deg);  <span class="comment">/* Opera 10.5-12.00 <span class="endcomment">*/</span></span>
-          transform: rotate(<b g="0">7.5</b>deg);  <span class="comment">/* Firefox 16+, Opera 12.50+ <span class="endcomment">*/</span>
+          transform: rotate(<b g="0">7.5</b>deg);  <span class="comment">/* Firefox 16+, Opera 12.50+ <span class="endcomment">*/</span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>
@@ -154,7 +154,7 @@
   -webkit-transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Safari 3.2+, Chrome <span class="endcomment">*/</span></span>
      -moz-transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Firefox 4-15 <span class="endcomment">*/</span></span>
        -o-transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Opera 10.5–12.00 <span class="endcomment">*/</span></span>
-          transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Firefox 16+, Opera 12.50+ <span class="endcomment">*/</span>
+          transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Firefox 16+, Opera 12.50+ <span class="endcomment">*/</span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>


### PR DESCRIPTION
The unclosed span tags on transition and transform would cause '{' to be included in clipboard when copying from the box_rotate and box_transition 
