### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
   -webkit-transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Chrome 1-25, Safari 3.2+ <span class="endcomment">*/</span></span>
      -moz-transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Firefox 4-15 <span class="endcomment">*/</span></span>
        -o-transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Opera 10.50–12.00 <span class="endcomment">*/</span></span>
-          transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Chrome 26, Firefox 16+, IE 10+, Opera 12.10+ <span class="endcomment">*/</span></span>
+          transition: <b g="0">all</b> <b g="1">0.3s</b> <b g="2">ease-out</b>;  <span class="comment">/* Chrome 26, Firefox 16+, IE 10+, Opera 12.10+, Safari 6.1+ <span class="endcomment">*/</span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>


### PR DESCRIPTION
transition: prefix free for Safari 6.1+
