### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,8 +177,8 @@
   <pre class="rule">
 * {
   -webkit-box-sizing: <b g="0">border-box</b>; <span class="comment">/* Android &le; 2.3, iOS &le; 4 <span class="endcomment">*/</span></span>
-     -moz-box-sizing: <b g="0">border-box</b>; <span class="comment">/* Firefox 1+ <span class="endcomment">*/</span></span>
-          box-sizing: <b g="0">border-box</b>; <span class="comment">/* Chrome, IE 8+, Opera, Safari 5.1 <span class="endcomment">*/</span></span>
+     -moz-box-sizing: <b g="0">border-box</b>; <span class="comment">/* Firefox &le; 28 <span class="endcomment">*/</span></span>
+          box-sizing: <b g="0">border-box</b>; <span class="comment">/* Chrome, Firefox 29+, IE 8+, Opera, Safari 5.1 <span class="endcomment">*/</span></span>
 }</pre>
   <pre class="rule comment commentclose"><span class="comment">/* */</span></pre>
 </div>


### PR DESCRIPTION
box-sizing without moz prefix on Firefox 29+
